### PR TITLE
Fix constructor check of flattenObject function

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -65,7 +65,7 @@ function flattenObject(ob) {
   const toReturn = {};
   /* eslint-disable */
   for (const i in ob) {
-    if (ob[i].constructor === Object) {
+    if (ob[i] && ob[i].constructor === Object) {
       const flatObject = flattenObject(ob[i]);
       for (const x in flatObject) {
         toReturn[`${i}.${x}`] = flatObject[x];


### PR DESCRIPTION
This adds simple check for a valid variable.
Should prevent error: Cannot read property 'constructor' of undefined.
Should resolve #66 